### PR TITLE
Send </stream:stream> when the Connection ends the stream

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -25,7 +25,7 @@
 
     "predef": [
       "define", "module", "require",
-      "before", "beforeEach", "describe", "it",
+      "before", "beforeEach", "afterEach", "describe", "it",
       "after", "window"
   ]
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -112,6 +112,13 @@ Connection.prototype._setupSocket = function (options) {
 
     inject(inject.options = options)
 
+    //wrap the end function provided by reconnect-core to trigger the stream end logic
+    var end = this.end;
+    this.end = this.disconnect = function() {
+        this.endStream();
+        end();
+    }
+
     this.on('connection', function () {
         if (!this.parser)
             this.startParser()

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -113,10 +113,10 @@ Connection.prototype._setupSocket = function (options) {
     inject(inject.options = options)
 
     //wrap the end function provided by reconnect-core to trigger the stream end logic
-    var end = this.end;
+    var end = this.end
     this.end = this.disconnect = function() {
-        this.endStream();
-        end();
+        this.endStream()
+        end()
     }
 
     this.on('connection', function () {
@@ -381,7 +381,7 @@ Connection.prototype.rmXmlns = function(stanza) {
  * XMPP-style end connection for user
  */
 Connection.prototype.onEnd = function() {
-    this.endStream();
+    this.endStream()
     if (!this.reconnect)
         this.emit('end')
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -262,6 +262,15 @@ Connection.prototype.startStream = function() {
     this.streamOpened = true
 }
 
+Connection.prototype.endStream = function() {
+    if (this.socket && this.socket.writable) {
+        if (this.streamOpened) {
+            this.socket.write('</stream:stream>')
+            delete this.streamOpened
+        }
+    }
+}
+
 Connection.prototype.onData = function(data) {
     debug('receive: ' + data.toString('utf8'))
     if (this.parser)
@@ -365,12 +374,7 @@ Connection.prototype.rmXmlns = function(stanza) {
  * XMPP-style end connection for user
  */
 Connection.prototype.onEnd = function() {
-    if (this.socket && this.socket.writable) {
-        if (this.streamOpened) {
-            this.socket.write('</stream:stream>')
-            delete this.streamOpened
-        }
-    }
+    this.endStream();
     if (!this.reconnect)
         this.emit('end')
 }

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,0 +1,111 @@
+'use strict';
+
+var assert = require('assert')
+  , xmpp = require('../index')
+  , net = require('net')
+  , ltx = require('ltx')
+
+var PORT = 8084 //Tests create a server on this port to attach sockets to
+
+describe('Connection', function () {
+    describe('socket config', function () {
+        it('allows a socket to be provided', function () {
+            var socket = new net.Socket()
+            var conn = new xmpp.Connection()
+            conn.connect({socket: socket})
+
+            assert.equal(conn.socket, socket)
+        })
+        it('allows a socket to be provided lazily', function () {
+            var socket = new net.Socket()
+            var socketFunc = function () {
+                return socket;
+            }
+            var conn = new xmpp.Connection()
+            conn.connect({
+                socket: socketFunc
+            })
+
+            assert.equal(conn.socket, socket)
+        })
+        it('defaults to using a net.Socket', function () {
+            var conn = new xmpp.Connection()
+            conn.connect({})
+
+            assert.equal(conn.socket instanceof net.Socket, true)
+        })
+    });
+
+    describe('<stream> handling', function () {
+        var conn
+        var server
+        var serverSocket
+
+        beforeEach(function (done) {
+            serverSocket = null
+            server = net.createServer(function (c) {
+                if(serverSocket) {
+                    assert.fail('Multiple connections to server; test case fail')
+                }
+                serverSocket = c
+
+                done()
+            });
+            server.listen(PORT)
+
+            conn = new xmpp.Connection()
+            var socket = new net.Socket()
+            conn.connect({socket: socket})
+            
+            socket.connect(PORT)
+        })
+
+        afterEach(function (done) {
+            serverSocket.end()
+            server.close(done)
+        })
+
+        it('sends <stream:stream > to start the stream', function (done) {
+            conn.startStream()
+
+            serverSocket.on('data', function (data) {
+                assert.equal(data.toString().indexOf('<stream:stream '), 0)
+                done()
+            })
+        })
+
+        it('sends </stream:stream> to close the stream when the connection is ended', function (done) {
+            serverSocket.on('data', function (data) {
+                var parsed = ltx.parse(data)
+                assert.equal(parsed.name, 'stream:stream')
+                done()
+            })
+
+            conn.startStream()
+
+            conn.end()
+        })
+
+        it('sends </stream:stream> to close the stream when the socket is ended from the other side', function (done) {
+
+            //If we don't allow halfOpen, the socket will close before it can send </stream>
+            conn.socket.allowHalfOpen = true;
+            conn.socket.on('end', function () {
+                conn.socket.end()
+            })
+
+            serverSocket.on('data', function (data) {
+                if(data.toString().indexOf('<stream:stream ') === 0) {
+                    serverSocket.end()
+                } else {
+                    assert.equal(data.toString(), '</stream:stream>')
+                    done()
+                }
+            })
+
+            conn.startStream()
+        })
+
+
+    })
+})


### PR DESCRIPTION
Currently logic exists to send the XMPP-specified `</stream:stream>` message when the connection is terminated from the other end; but no analogous logic exists to send the message when the `Connection.end` method is called to end the connection; this PR adds that logic.  