### PR TITLE
update deps to support node v0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "url": "https://github.com/node-xmpp/node-xmpp-core/issues"
   },
   "dependencies": {
-    "node-stringprep": "~0.2.0",
+    "node-stringprep": "~0.7.0",
     "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged",
-    "tls-connect": "~0.2.1",
-    "ltx": "~0.3.3",
+    "tls-connect": "~0.2.2",
+    "ltx": "~0.9.0",
     "debug": "~0.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I cannot install the latest stable with node `v0.12.x` because of its dependencies. Updating the deps would help. Can we create a `v0.4.x` branch and publish a `v0.4.11` version?
(there is also a `v0.5` on npmjs but the git repo has no corresponding tag).