### PR TITLE
* Comply with RFC 7395 XMPP over WebSockets (hack).

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,6 +13,7 @@ var net = require('net')
 var NS_XMPP_TLS = 'urn:ietf:params:xml:ns:xmpp-tls'
 var NS_STREAM = 'http://etherx.jabber.org/streams'
 var NS_XMPP_STREAMS = 'urn:ietf:params:xml:ns:xmpp-streams'
+var NS_XMPP_FRAMING = 'urn:ietf:params:xml:ns:xmpp-framing'
 
 var INITIAL_RECONNECT_DELAY = 1e3
 var MAX_RECONNECT_DELAY     = 30e3
@@ -264,13 +265,25 @@ Connection.prototype.startStream = function() {
         attrs.to = this.streamTo
     }
 
-    var el = new ltx.Element('stream:stream', attrs)
-    // make it non-empty to cut the closing tag
-    el.t(' ')
-    var s = el.toString()
-    this.send(s.substr(0, s.indexOf(' </stream:stream>')))
 
-    this.streamOpened = true
+    if(this.streamNsAttrs['xmlns'] == NS_XMPP_FRAMING){
+        delete attrs['xmlns:stream']
+        attrs.xmlns = NS_XMPP_FRAMING;
+        //attrs.id = '++' + Math.random() + "+xxx";
+        var el = new ltx.Element('open', attrs)
+        var s = el.toString()
+        this.streamNsAttrs['xmlns'] = NS_STREAM
+        this.send(s)
+        this.frameOpened = true
+    }else {
+        var el = new ltx.Element('stream:stream', attrs)
+        // make it non-empty to cut the closing tag
+        el.t(' ')
+        var s = el.toString()
+        this.send(s.substr(0, s.indexOf(' </stream:stream>')))
+
+        this.streamOpened = true
+    }
 }
 
 Connection.prototype.endStream = function() {
@@ -279,6 +292,9 @@ Connection.prototype.endStream = function() {
             this.socket.write('</stream:stream>')
             this.streamOpened = false
         }
+        /*if(this.frameOpened){
+            this.socket.write('<close xmlns="' + NS_XMPP_FRAMING + '" />')
+        }*/
     }
 }
 

--- a/lib/stream_parser.js
+++ b/lib/stream_parser.js
@@ -4,6 +4,7 @@ var util = require('util')
   , EventEmitter = require('events').EventEmitter
   , ltx = require('ltx')
   , Stanza = require('./stanza').Stanza
+  , debug = require('debug')('xmpp-core:stream_parser')
 
 /**
  * Recognizes <stream:stream> and collects stanzas used for ordinary
@@ -26,7 +27,7 @@ function StreamParser(maxStanzaSize) {
 
     this.parser.on('startElement', function(name, attrs) {
             // TODO: refuse anything but <stream:stream>
-            if (!self.element && (name === 'stream:stream')) {
+            if (!self.element && ((name === 'stream:stream') || (name === 'open'))) {
                 self.emit('streamStart', attrs)
             } else {
                 var child
@@ -46,8 +47,11 @@ function StreamParser(maxStanzaSize) {
     )
 
     this.parser.on('endElement', function(name) {
-        if (!self.element && (name === 'stream:stream')) {
-            self.end()
+        if (!self.element && ((name === 'stream:stream') || (name === 'open'))) {
+            if(name !== 'open') { // Do nothing with <open ../>
+                debug('calling end on endElement')
+                self.end()
+            }
         } else if (self.element && (name === self.element.name)) {
             if (self.element.parent) {
                 self.element = self.element.parent
@@ -100,7 +104,7 @@ StreamParser.prototype.checkXMLHeader = function (data) {
             data = data.replace(search, '');
         }
     }
-
+    this.parser.reset()
     return data;
 }
 


### PR DESCRIPTION
We treat `<open..>` WebSockets RFC 7395 (http://tools.ietf.org/html/rfc7395#section-3.1) as a `<stream:stream>` and respond in the same manner.
We also need to call this.parser.reset() (exposed on PR for ltx sax_expat.js) to tell it that each statement is a new document by itself.