### PR TITLE
Use explicit socket.removeListener calls instead of socket.removeAllListeners when upgrading to TLS

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -56,6 +56,11 @@ function Connection (opts) {
 
   this.servername = (opts && opts.servername)
 
+  this.boundOnData = this.onData.bind(this)
+  this.boundOnClose = this.onClose.bind(this)
+  this.boundEmitData = this.emit.bind(this, 'data')
+  this.boundEmitDrain = this.emit.bind(this, 'drain')
+
   this._setupSocket(defaultInjection(this, opts))
   this.once('reconnect', function () {
     this.reconnect = opts && opts.reconnect
@@ -138,11 +143,11 @@ Connection.prototype._setupSocket = function (options) {
 Connection.prototype.setupStream = function () {
   debug('setup stream')
   this.socket.on('end', this.onEnd.bind(this))
-  this.socket.on('data', this.onData.bind(this))
-  this.socket.on('close', this.onClose.bind(this))
+  this.socket.on('data', this.boundOnData)
+  this.socket.on('close', this.boundOnClose)
   // let them sniff unparsed XML
-  this.socket.on('data', this.emit.bind(this, 'data'))
-  this.socket.on('drain', this.emit.bind(this, 'drain'))
+  this.socket.on('data', this.boundEmitData)
+  this.socket.on('drain', this.boundEmitDrain)
   // ignore errors after disconnect
   this.socket.on('error', function () {})
 
@@ -308,10 +313,12 @@ Connection.prototype.onData = function (data) {
 
 Connection.prototype.setSecure = function (credentials, isServer) {
   // Remove old event listeners
-  this.socket.removeAllListeners('data')
+  this.socket.removeListener('data', this.boundOnData)
+  this.socket.removeListener('data', this.boundEmitData)
+
   // retain socket 'end' listeners because ssl layer doesn't support it
-  this.socket.removeAllListeners('drain')
-  this.socket.removeAllListeners('close')
+  this.socket.removeListener('drain', this.boundEmitDrain)
+  this.socket.removeListener('close', this.boundOnClose)
   // remove idle_timeout
   if (this.socket.clearTimer) {
     this.socket.clearTimer()


### PR DESCRIPTION
The use of socket.removeAllListeners during the TLS upgrade, causes a memory leak in node-xmpp-server.  

This commit fixes node-xmpp/node-xmpp-server#139